### PR TITLE
修复/优化两个小问题

### DIFF
--- a/lib/acts_as_followable/followable.rb
+++ b/lib/acts_as_followable/followable.rb
@@ -25,7 +25,7 @@ module ActsAsFollowable
         ids = Follow.
           where('followable_id' => self.id,
                 'followable_type' => class_name(self),
-                'follower_type' => follower_type
+                'follower_type' => follower_type.name
         ).pluck('follower_id')
         return follower_type.find(ids)
       end

--- a/lib/acts_as_followable/followable.rb
+++ b/lib/acts_as_followable/followable.rb
@@ -27,7 +27,7 @@ module ActsAsFollowable
                 'followable_type' => class_name(self),
                 'follower_type' => follower_type.name
         ).pluck('follower_id')
-        return follower_type.find(ids)
+        return follower_type.where("id in (?)", ids)
       end
     end
   end


### PR DESCRIPTION
两个 commit:

1. `follower_type` 是 `class`, 不用 `name` 方法会有 `can't cast Class` 的错误
2. `find(ids)` 返回一个数组，`where` 返回的是 `ActiveRecord_Relation` 更强大灵活